### PR TITLE
Improve text area behaviour

### DIFF
--- a/src/CaptainsLog/ui/TextArea.java
+++ b/src/CaptainsLog/ui/TextArea.java
@@ -35,6 +35,7 @@ public class TextArea {
             // multi-lines break cursor display
             field.hideCursor();
         }
+        field.setUndoOnEscape(false);
         inner.addUIElement(tooltip);
         panel.addComponent(inner).inTL(x, y);
         return field;


### PR DESCRIPTION
- Do not accept `Keyboard.KEY_RETURN` keypresses adding newline and retaking focus unless this specific `TextArea` object last had focus. Focus is lost when:
    - clicking outside the area with the mouse o
    - pressing `Keyboard.KEY_ESCAPE` (matches vanilla TextFieldAPI impl)
- Do not erase last line when pressing `Keyboard.KEY_ESCAPE`